### PR TITLE
fix: search fix in get info and add info pages

### DIFF
--- a/src/views/Seek/Seek.js
+++ b/src/views/Seek/Seek.js
@@ -79,9 +79,8 @@ const Seek = () => {
     }, [])
 
     useEffect(() => {
-        if(!(params.city === "" && params.type === "" && params.query === "")){
-            setLoading(true)
-            service.get(`${FORM_FILL_STRUCTURED}?city=${params.city ? params.city : 'null' }&requestType=${params.type ? params.type : 'null'}&q=${params.query ? params.query : 'null'}&isSeeker=${seeker}`)
+        setLoading(true)
+        service.get(`${FORM_FILL_STRUCTURED}?city=${params.city ? params.city : 'null' }&requestType=${params.type ? params.type : 'null'}&q=${params.query ? params.query : 'null'}&isSeeker=${seeker}`)
             .then(res => {
                 console.log(res);
                 if(res.data.success){
@@ -100,7 +99,6 @@ const Seek = () => {
                 console.log(err);
             })
             .finally(() => setLoading(false))
-        }
     }, [params])
 
     const updateCard = data => {
@@ -150,7 +148,7 @@ const Seek = () => {
                     {
                         cards && cards.map((c, ind) => {
                             return (
-                                <Card isLink={uuid === undefined ? false: true} key={ind} {...c} updateCard={updateCard} />
+                                <Card isLink={uuid !== undefined} key={ind} {...c} updateCard={updateCard} />
                             )
                         })
                     }
@@ -168,12 +166,12 @@ const Seek = () => {
                         !seeker ?
                         cards && cards.map((c, ind) => {
                             return (
-                                c.isGiver && <Card isLink={uuid === undefined ? false: true} key={ind} {...c} updateCard={updateCard} />
+                                c.isGiver && <Card isLink={uuid !== undefined} key={ind} {...c} updateCard={updateCard} />
                             )
                         }) :
                         cards && cards.map((c, ind) => {
                             return (
-                                !c.isGiver && <Card isLink={uuid === undefined ? false: true} key={ind} {...c} updateCard={updateCard} />
+                                !c.isGiver && <Card isLink={uuid !== undefined} key={ind} {...c} updateCard={updateCard} />
                             )
                         })
                     ) : null


### PR DESCRIPTION
Clearing out search tokens should fire an api call. Inorder to reproduce this,
search for `;`, results are empty as expected. if i remove that `;`, call should be fired. but it doesn't and some minor fixes.


![image](https://user-images.githubusercontent.com/49393831/115498910-0486db00-a28c-11eb-8b57-d09a522bff4f.png)
![image](https://user-images.githubusercontent.com/49393831/115498918-0b155280-a28c-11eb-8d0b-841a5e49d0ea.png)
